### PR TITLE
Update BMXCore.podspec - Prevent Alamofire incompatibilities

### DIFF
--- a/BMXCore.podspec
+++ b/BMXCore.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'BMXCore.xcframework'
 
   s.dependency 'Japx/Alamofire'
-  s.dependency 'Alamofire', '~> 5.2.1'
+  s.dependency 'Alamofire'
   s.dependency 'OAuthSwift', '2.1.0'
 end


### PR DESCRIPTION
I don't know if this is the correct solution but most consumers of this SDK aren't going to be on exactly v5.2.1. In fact, we have hit installation issues due to being on 5.4.4. We also plan on moving to 5.6 in the coming months as we begin to adopt async/await.